### PR TITLE
fix a formatting error

### DIFF
--- a/core/generate_value/README.md
+++ b/core/generate_value/README.md
@@ -37,7 +37,7 @@ coverage: 0.7444444444444445
 
 ### Result
 
-The generated value result will be in `<project>-generated-values.txt` (tab-seperated), which looks like
+The generated value result will be in `<project>-generated-values.tsv` (tab-seperated), which looks like
 
 ```
 hadoop.http.filter.initializers	SKIP	SKIP


### PR DESCRIPTION
The generated value will be stored in the file with tsv format instead of txt which is defined in value_generation.py line 9. 