### PR TITLE
Modify docker setup to allow easy dev

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -36,7 +36,9 @@ RUN \
   useradd -m ctestuser
 
 USER ctestuser
-RUN cd /home/ctestuser && \
-  git clone https://github.com/xlab-uiuc/openctest.git
+# RUN cd /home/ctestuser && \
+#   git clone https://github.com/xlab-uiuc/openctest.git
 
 WORKDIR /home/ctestuser
+
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: "3.0"
+services:
+    openctest:
+        build: ./core
+        volumes:
+            - .:/home/ctestuser/openctest
+        container_name: openctest


### PR DESCRIPTION
Currently Dockerfile clones the github repo,
so if I want to use Docker for development,
I can't do that. I'd need to make a change,
push to master and then build the Docker image.

Instead now the docker container will come up with
mapping the code onto /home/ctestuser/openctest
This way modifications outside the container
will reflect inside, making it easier to test.

