### PR TITLE
skipTrace tiny fix

### DIFF
--- a/core/identify_param/runner.py
+++ b/core/identify_param/runner.py
@@ -61,7 +61,7 @@ class Runner:
         return False
 
     def skipTrace(self, trace):
-        if trace == "java.lang.Thread":
+        if "java.lang.Thread" in trace:
             return True
         if "sun.reflect" in trace:
             return True


### PR DESCRIPTION
As mentioned [in the 6th PR](https://github.com/xlab-uiuc/openctest/pull/6), 
In the 64th line of [/identify_param/runner.py](https://github.com/xlab-uiuc/openctest/blob/main/core/identify_param/runner.py#L64), we have the if statement
if trace == "java.lang.Thread"
This works with the trivial log trace like the commit [here](https://github.com/xlab-uiuc/zookeeper/commit/b389ba8bfbc861dc034dcd3bdc6227fd29dea558#diff-c184aadd789e20edde3f3f4a95c8d6f2ae0802c90fae2ed11df8878062fd0a1fR741) which the trace only contains the class name. 
But based on our review of the past projects ctest supports and how Logging Configuration API was those projects were being modified, we found out that the if statement above is not applicable to all the LOG sentences for sometimes the trace contains more information like line numbers, like the example in this commit(https://github.com/xlab-uiuc/hadoop/commit/21010037e2a111d3122fd46209879db17a6667b4).  Changing the if statement above into
if "java.lang.Thread" in trace
could help solve the problem.