### PR TITLE
add count_test, filter_param, ctest_indent

### DIFF
--- a/core/generate_ctest/count_test_on_each_param.py
+++ b/core/generate_ctest/count_test_on_each_param.py
@@ -1,0 +1,16 @@
+## By Oscar Chen and Chris Shen from CS527, Fall 2022 
+## This program will generate a "{project}_test_num_on_param.txt" file in same directory that records the number of test methods related to each param.
+## In each line of the generated file, the number of tests methods always comes before the param name
+## File required: openctest/data/ctest_mapping/opensource-{project}.json
+##                openctest/core/generate_value/{project}-generated-values.tsv
+import json
+from program_input import p_input
+j = json.load(open("../../data/ctest_mapping/opensource-"+p_input["project"]+".json"))
+c = {}
+for p in open("../generate_value/"+p_input["project"]+"-generated-values.tsv").readlines():
+    key = p.split("\t")[0]
+    if (key in j.keys()):
+        c.update({key: len(j[key])})
+with open(p_input["project"]+"_test_num_on_param.txt", "w") as outfile:
+    for k in c.keys():
+        outfile.write(str(c[k])+"\t"+k+"\n")

--- a/core/generate_ctest/ctest_indent.py
+++ b/core/generate_ctest/ctest_indent.py
@@ -1,0 +1,7 @@
+## By Oscar Chen and Chris Shen from CS527, Fall 2022 
+## This program helps create an indented version of ctests-{project}.json
+## Fire required: openctest/core/generate_ctest/ctest_mapping/ctests-{project}.json
+import json
+from program_input import p_input
+j = json.load(open("ctest_mapping/ctests-"+p_input["project"]+".json"))
+json.dump(j, open("ctest_mapping/ctests-"+p_input["project"]+"-indent.json", "w"), indent=4)

--- a/core/generate_ctest/filter_param_by_test_num.py
+++ b/core/generate_ctest/filter_param_by_test_num.py
@@ -1,0 +1,16 @@
+## By Oscar Chen and Chris Shen from CS527, Fall 2022 
+## This program will filter the params with number of test reference in between min and max
+## The selected params will be saved in {project}.tsv in same directory
+## Fill free to modify min and max to what you need
+## File required: openctest/data/ctest_mapping/opensource-{project}.json
+##                openctest/core/generate_value/{project}-generated-values.tsv
+import json
+from program_input import p_input
+min = 0
+max = 50
+j = json.load(open("../../data/ctest_mapping/opensource-"+p_input["project"]+".json"))
+w = open(p_input["project"]+".tsv", "w")
+for p in open("../generate_value/"+p_input["project"]+"-generated-values.tsv").readlines():
+    key = p.split("\t")[0]
+    if key in j.keys() and (len(j[key]) >= min) and (len(j[key]) < max):
+        w.write(p)


### PR DESCRIPTION
Three programs are created for some missing functions in current openctest:

The first program ([count_test_on_each_param.py](https://github.com/chrisshen98/openctest/blob/new-functions/core/generate_ctest/count_test_on_each_param.py)) traverse through each parameter and calculates the number of test methods that make use of this parameter;

The second program ([filter_param_by_test_num.py](https://github.com/chrisshen98/openctest/blob/new-functions/core/generate_ctest/filter_param_by_test_num.py)) filters the list of parameter (with generated good and bad values) with number of test method within given min and max;

The third program ([ctest_indent.py](https://github.com/chrisshen98/openctest/blob/new-functions/core/generate_ctest/ctest_indent.py)) takes in the ctests-{project}.json generated in openctest/core/generate_ctest/ctest_mapping and make an indented version for more intuitive visual effect.