### PR TITLE
fix(docker): apt-get python2 is no longer available

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   apt-get install -y git && \
 # Install python
   apt-get update && \
-  apt-get install -y python python-dev python-pip python-virtualenv && \
+  apt-get install -y python3 python3-dev python3-pip python3-venv && \
   rm -rf /var/lib/apt/lists/* && \
 # Install misc
   apt-get update && \


### PR DESCRIPTION
Thanks for your work! A little chore:

`python-pip`, `python-virtualenv` (python2) packages are no longer available in modern distributions. Use python3 instead.